### PR TITLE
Refactor play command to use ytdl-core and split into audio/video com…

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ import { readSettings } from './lib/functions.js';
 
 const logger = pino({ level: 'silent' }).child({ level: 'silent' });
 const commands = new Map();
-export const playMessageCache = new Map(); // Cache for play command messages
 let botSettings = {};
 
 // --- CARGADOR DE COMANDOS ---
@@ -71,49 +70,6 @@ async function connectToWhatsApp() {
 
         const remoteJid = msg.key.remoteJid;
         const messageType = Object.keys(msg.message)[0];
-
-        // --- MANEJO DE REACCIONES PARA DESCARGAS ---
-        if (messageType === 'protocolMessage' && msg.message.protocolMessage.type === 'MESSAGE_REACTION') {
-            const reaction = msg.message.protocolMessage;
-            const reactedMsgKey = reaction.key;
-
-            if (playMessageCache.has(reactedMsgKey.id)) {
-                const { url, quotedMsg } = playMessageCache.get(reactedMsgKey.id);
-                const emoji = reaction.reaction.text;
-                let action;
-
-                if (emoji === '♬') {
-                    action = 'download_audio';
-                } else if (emoji === '📹') {
-                    action = 'download_video';
-                } else {
-                    return; // Ignorar otras reacciones
-                }
-
-                await sock.sendMessage(remoteJid, { text: 'Descargando, por favor espera...' }, { quoted: quotedMsg });
-                try {
-                    const apiUrl = action === 'download_audio'
-                        ? `https://myapiadonix.vercel.app/api/ytmp3?url=${encodeURIComponent(url)}`
-                        : `https://myapiadonix.vercel.app/api/ytmp4?url=${encodeURIComponent(url)}`;
-
-                    const response = await axios.get(apiUrl, { responseType: 'arraybuffer' });
-                    const mediaBuffer = Buffer.from(response.data, 'binary');
-
-                    if (action === 'download_audio') {
-                        await sock.sendMessage(remoteJid, { audio: mediaBuffer, mimetype: 'audio/mp4' }, { quoted: quotedMsg });
-                    } else {
-                        await sock.sendMessage(remoteJid, { video: mediaBuffer, mimetype: 'video/mp4' }, { quoted: quotedMsg });
-                    }
-                } catch (error) {
-                    console.error("Error en la descarga por reacción:", error);
-                    await sock.sendMessage(remoteJid, { text: 'Hubo un error al descargar el archivo.' }, { quoted: quotedMsg });
-                } finally {
-                    playMessageCache.delete(reactedMsgKey.id); // Limpiar el caché
-                }
-                return;
-            }
-        }
-
 
         // --- MANEJO DE COMANDOS DE TEXTO ---
         const messageContent = messageType === 'conversation' ? msg.message.conversation :

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "qrcode": "^1.5.3",
         "socket.io": "^4.7.5",
         "wa-sticker-formatter": "^4.4.4",
-        "yt-search": "^2.10.4"
+        "yt-search": "^2.10.4",
+        "ytdl-core": "^4.11.5"
       }
     },
     "node_modules/@cacheable/node-cache": {
@@ -3017,6 +3018,19 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/m3u8stream": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
+      "integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
+      "license": "MIT",
+      "dependencies": {
+        "miniget": "^4.2.2",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3127,6 +3141,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/miniget": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.3.tgz",
+      "integrity": "sha512-SjbDPDICJ1zT+ZvQwK0hUcRY4wxlhhNpHL9nJOB2MEAXRGagTljsO8MEDzQMTFf0Q8g4QNi8P9lEm/g7e+qgzA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/minimatch": {
@@ -4013,6 +4036,12 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -5001,6 +5030,20 @@
         "yt-search": "bin/cli.js",
         "yt-search-audio": "bin/mpv_audio.sh",
         "yt-search-video": "bin/mpv_video.sh"
+      }
+    },
+    "node_modules/ytdl-core": {
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.5.tgz",
+      "integrity": "sha512-27LwsW4n4nyNviRCO1hmr8Wr5J1wLLMawHCQvH8Fk0hiRqrxuIu028WzbJetiYH28K8XDbeinYW4/wcHQD1EXA==",
+      "license": "MIT",
+      "dependencies": {
+        "m3u8stream": "^0.8.6",
+        "miniget": "^4.2.2",
+        "sax": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "qrcode": "^1.5.3",
     "socket.io": "^4.7.5",
     "yt-search": "^2.10.4",
-    "wa-sticker-formatter": "^4.4.4"
+    "wa-sticker-formatter": "^4.4.4",
+    "ytdl-core": "^4.11.5"
   }
 }

--- a/plugins/play2.js
+++ b/plugins/play2.js
@@ -2,14 +2,14 @@ import ytSearch from 'yt-search';
 import ytdl from 'ytdl-core';
 
 export default {
-    name: 'play',
+    name: 'play2',
     category: 'downloader',
-    description: 'Busca y descarga una canción de YouTube.',
+    description: 'Busca y descarga un video de YouTube.',
 
     async execute({ sock, msg, args }) {
         const query = args.join(' ');
         if (!query) {
-            return await sock.sendMessage(msg.key.remoteJid, { text: 'Por favor, proporciona el nombre de una canción.' }, { quoted: msg });
+            return await sock.sendMessage(msg.key.remoteJid, { text: 'Por favor, proporciona el nombre de un video.' }, { quoted: msg });
         }
 
         try {
@@ -27,12 +27,11 @@ export default {
 
             await sock.sendMessage(msg.key.remoteJid, {
                 image: { url: video.thumbnail },
-                caption: caption + '\n\nDescargando audio, por favor espera...'
+                caption: caption + '\n\nDescargando video, por favor espera...'
             }, { quoted: msg });
 
             const stream = ytdl(videoUrl, {
-                filter: 'audioonly',
-                quality: 'lowestaudio'
+                quality: 'highest'
             });
 
             const chunks = [];
@@ -43,19 +42,20 @@ export default {
             stream.on('end', async () => {
                 const buffer = Buffer.concat(chunks);
                 await sock.sendMessage(msg.key.remoteJid, {
-                    audio: buffer,
-                    mimetype: 'audio/mp4'
+                    video: buffer,
+                    mimetype: 'video/mp4',
+                    caption: caption
                 }, { quoted: msg });
             });
 
             stream.on('error', async (err) => {
-                console.error('Error al descargar el audio:', err);
-                await sock.sendMessage(msg.key.remoteJid, { text: 'Ocurrió un error al descargar el audio.' }, { quoted: msg });
+                console.error('Error al descargar el video:', err);
+                await sock.sendMessage(msg.key.remoteJid, { text: 'Ocurrió un error al descargar el video.' }, { quoted: msg });
             });
 
         } catch (error) {
-            console.error('Error en el comando play:', error);
-            await sock.sendMessage(msg.key.remoteJid, { text: 'Ocurrió un error al buscar la canción.' }, { quoted: msg });
+            console.error('Error en el comando play2:', error);
+            await sock.sendMessage(msg.key.remoteJid, { text: 'Ocurrió un error al buscar el video.' }, { quoted: msg });
         }
     }
 };


### PR DESCRIPTION
…mands

- Replaced the error-prone external API for downloads with the `ytdl-core` library for improved reliability.
- Split the original `play` command into two distinct commands:
  - `play`: Searches and downloads audio from YouTube.
  - `play2`: Searches and downloads video from YouTube.
- Removed the obsolete reaction-based download handler from `index.js`.
- Added `ytdl-core` as a project dependency.

This resolves the issue of the play plugin failing and provides a more robust and direct download implementation as requested.