### PR TITLE
feat: Refactor play command to use ytdl-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "whatsapp-bot",
       "version": "1.0.0",
       "dependencies": {
+        "@distube/ytdl-core": "^4.16.12",
         "@whiskeysockets/baileys": "^6.7.2",
         "axios": "^1.7.2",
         "express": "^4.19.2",
@@ -15,8 +16,7 @@
         "qrcode": "^1.5.3",
         "socket.io": "^4.7.5",
         "wa-sticker-formatter": "^4.4.4",
-        "yt-search": "^2.10.4",
-        "ytdl-core": "^4.11.5"
+        "yt-search": "^2.10.4"
       }
     },
     "node_modules/@cacheable/node-cache": {
@@ -31,6 +31,27 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@distube/ytdl-core": {
+      "version": "4.16.12",
+      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.16.12.tgz",
+      "integrity": "sha512-/NR8Jur1Q4E2oD+DJta7uwWu7SkqdEkhwERt7f4iune70zg7ZlLLTOHs1+jgg3uD2jQjpdk7RGC16FqstG4RsA==",
+      "license": "MIT",
+      "dependencies": {
+        "http-cookie-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "m3u8stream": "^0.8.6",
+        "miniget": "^4.2.3",
+        "sax": "^1.4.1",
+        "tough-cookie": "^5.1.2",
+        "undici": "^7.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/distubejs/ytdl-core?sponsor"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -803,6 +824,15 @@
       "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2656,6 +2686,30 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/http-cookie-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-7.0.2.tgz",
+      "integrity": "sha512-aHaES6SOFtnSlmWu0yEaaQvu+QexUG2gscSAvMhJ7auzW8r/jYOgGrzuAm9G9nHbksuhz7Lw4zOwDHmfQaxZvw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0 || ^5.0.0",
+        "undici": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2670,6 +2724,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-time": {
@@ -4554,6 +4621,24 @@
         "real-require": "^0.2.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4590,6 +4675,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5030,20 +5127,6 @@
         "yt-search": "bin/cli.js",
         "yt-search-audio": "bin/mpv_audio.sh",
         "yt-search-video": "bin/mpv_video.sh"
-      }
-    },
-    "node_modules/ytdl-core": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.5.tgz",
-      "integrity": "sha512-27LwsW4n4nyNviRCO1hmr8Wr5J1wLLMawHCQvH8Fk0hiRqrxuIu028WzbJetiYH28K8XDbeinYW4/wcHQD1EXA==",
-      "license": "MIT",
-      "dependencies": {
-        "m3u8stream": "^0.8.6",
-        "miniget": "^4.2.2",
-        "sax": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=12"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "socket.io": "^4.7.5",
     "yt-search": "^2.10.4",
     "wa-sticker-formatter": "^4.4.4",
-    "ytdl-core": "^4.11.5"
+    "@distube/ytdl-core": "^4.16.12"
   }
 }

--- a/plugins/play.js
+++ b/plugins/play.js
@@ -1,5 +1,5 @@
 import ytSearch from 'yt-search';
-import ytdl from 'ytdl-core';
+import ytdl from '@distube/ytdl-core';
 
 export default {
     name: 'play',

--- a/plugins/play2.js
+++ b/plugins/play2.js
@@ -1,5 +1,5 @@
 import ytSearch from 'yt-search';
-import ytdl from 'ytdl-core';
+import ytdl from '@distube/ytdl-core';
 
 export default {
     name: 'play2',


### PR DESCRIPTION
- Replaced an unreliable external API with the `ytdl-core` library for downloading media from YouTube.
- Split the original `play` command into two distinct commands for better usability:
  - `play`: Searches and downloads audio.
  - `play2`: Searches and downloads video.
- Removed the old, error-prone reaction-based download logic from `index.js`.

fix: Update ytdl-core to resolve signature errors

- Replaced the `ytdl-core` package with the more actively maintained `@distube/ytdl-core` fork.
- This resolves the `sig.js` signature deciphering error that was preventing downloads, ensuring the feature remains functional as YouTube updates its backend.