### PR TITLE
feat(youtube): Refactor play command and fix download errors

### DIFF
--- a/plugins/play.js
+++ b/plugins/play.js
@@ -6,7 +6,7 @@ export default {
     category: 'downloader',
     description: 'Busca y descarga una canción de YouTube.',
 
-    async execute({ sock, msg, args }) {
+    async execute({ sock, msg, args, settings }) {
         const query = args.join(' ');
         if (!query) {
             return await sock.sendMessage(msg.key.remoteJid, { text: 'Por favor, proporciona el nombre de una canción.' }, { quoted: msg });
@@ -30,10 +30,17 @@ export default {
                 caption: caption + '\n\nDescargando audio, por favor espera...'
             }, { quoted: msg });
 
-            const stream = ytdl(videoUrl, {
+            const ytdlOptions = {
                 filter: 'audioonly',
-                quality: 'lowestaudio'
-            });
+                quality: 'lowestaudio',
+                requestOptions: {
+                    headers: {
+                        cookie: settings.youtubeCookies || '',
+                    },
+                },
+            };
+
+            const stream = ytdl(videoUrl, ytdlOptions);
 
             const chunks = [];
             stream.on('data', (chunk) => {

--- a/plugins/play2.js
+++ b/plugins/play2.js
@@ -6,7 +6,7 @@ export default {
     category: 'downloader',
     description: 'Busca y descarga un video de YouTube.',
 
-    async execute({ sock, msg, args }) {
+    async execute({ sock, msg, args, settings }) {
         const query = args.join(' ');
         if (!query) {
             return await sock.sendMessage(msg.key.remoteJid, { text: 'Por favor, proporciona el nombre de un video.' }, { quoted: msg });
@@ -30,9 +30,16 @@ export default {
                 caption: caption + '\n\nDescargando video, por favor espera...'
             }, { quoted: msg });
 
-            const stream = ytdl(videoUrl, {
-                quality: 'highest'
-            });
+            const ytdlOptions = {
+                quality: 'highest',
+                requestOptions: {
+                    headers: {
+                        cookie: settings.youtubeCookies || '',
+                    },
+                },
+            };
+
+            const stream = ytdl(videoUrl, ytdlOptions);
 
             const chunks = [];
             stream.on('data', (chunk) => {


### PR DESCRIPTION
This commit completely revamps the YouTube download functionality to address multiple errors and improve usability.

- Replaced an unreliable external API with the `ytdl-core` library for downloading media directly from YouTube.
- Split the original `play` command into two distinct commands:
  - `play`: Searches and downloads audio.
  - `play2`: Searches and downloads video.
- Removed the old, error-prone reaction-based download logic from `index.js`.

fix(youtube): Update ytdl-core and implement cookie-based downloads

- Replaced the `ytdl-core` package with the more actively maintained `@distube/ytdl-core` fork to resolve initial signature (`sig.js`) errors.
- Implemented cookie-based authentication for downloads to resolve subsequent `403 Forbidden` errors.
- The `play` and `play2` commands now read YouTube cookies from a `youtubeCookies` field in `settings.json`, making the download process more robust and stable.