### PR TITLE
feat: Replace ytdl-core with Apify API for downloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "whatsapp-bot",
       "version": "1.0.0",
       "dependencies": {
-        "@distube/ytdl-core": "^4.16.12",
         "@whiskeysockets/baileys": "^6.7.2",
         "axios": "^1.7.2",
         "express": "^4.19.2",
@@ -31,27 +30,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@distube/ytdl-core": {
-      "version": "4.16.12",
-      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.16.12.tgz",
-      "integrity": "sha512-/NR8Jur1Q4E2oD+DJta7uwWu7SkqdEkhwERt7f4iune70zg7ZlLLTOHs1+jgg3uD2jQjpdk7RGC16FqstG4RsA==",
-      "license": "MIT",
-      "dependencies": {
-        "http-cookie-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "m3u8stream": "^0.8.6",
-        "miniget": "^4.2.3",
-        "sax": "^1.4.1",
-        "tough-cookie": "^5.1.2",
-        "undici": "^7.8.0"
-      },
-      "engines": {
-        "node": ">=20.18.1"
-      },
-      "funding": {
-        "url": "https://github.com/distubejs/ytdl-core?sponsor"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -824,15 +802,6 @@
       "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2686,30 +2655,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/http-cookie-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-7.0.2.tgz",
-      "integrity": "sha512-aHaES6SOFtnSlmWu0yEaaQvu+QexUG2gscSAvMhJ7auzW8r/jYOgGrzuAm9G9nHbksuhz7Lw4zOwDHmfQaxZvw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.4"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/3846masa"
-      },
-      "peerDependencies": {
-        "tough-cookie": "^4.0.0 || ^5.0.0",
-        "undici": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "undici": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2724,19 +2669,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/human-time": {
@@ -3085,19 +3017,6 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
-    "node_modules/m3u8stream": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
-      "integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
-      "license": "MIT",
-      "dependencies": {
-        "miniget": "^4.2.2",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3208,15 +3127,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/miniget": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.3.tgz",
-      "integrity": "sha512-SjbDPDICJ1zT+ZvQwK0hUcRY4wxlhhNpHL9nJOB2MEAXRGagTljsO8MEDzQMTFf0Q8g4QNi8P9lEm/g7e+qgzA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/minimatch": {
@@ -4104,12 +4014,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC"
-    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -4621,24 +4525,6 @@
         "real-require": "^0.2.0"
       }
     },
-    "node_modules/tldts": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tldts-core": "^6.1.86"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "node_modules/tldts-core": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "license": "MIT"
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4675,18 +4561,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^6.1.32"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "qrcode": "^1.5.3",
     "socket.io": "^4.7.5",
     "yt-search": "^2.10.4",
-    "wa-sticker-formatter": "^4.4.4",
-    "@distube/ytdl-core": "^4.16.12"
+    "wa-sticker-formatter": "^4.4.4"
   }
 }

--- a/plugins/play.js
+++ b/plugins/play.js
@@ -1,15 +1,19 @@
 import ytSearch from 'yt-search';
-import ytdl from '@distube/ytdl-core';
+import axios from 'axios';
 
 export default {
     name: 'play',
     category: 'downloader',
-    description: 'Busca y descarga una canción de YouTube.',
+    description: 'Busca y descarga una canción de YouTube usando la API de Apify.',
 
     async execute({ sock, msg, args, settings }) {
         const query = args.join(' ');
         if (!query) {
             return await sock.sendMessage(msg.key.remoteJid, { text: 'Por favor, proporciona el nombre de una canción.' }, { quoted: msg });
+        }
+
+        if (!settings.apifyToken) {
+            return await sock.sendMessage(msg.key.remoteJid, { text: 'El token de la API de Apify no está configurado. Por favor, añádelo al archivo settings.json.' }, { quoted: msg });
         }
 
         try {
@@ -30,39 +34,35 @@ export default {
                 caption: caption + '\n\nDescargando audio, por favor espera...'
             }, { quoted: msg });
 
-            const ytdlOptions = {
-                filter: 'audioonly',
-                quality: 'lowestaudio',
-                requestOptions: {
-                    headers: {
-                        cookie: settings.youtubeCookies || '',
-                    },
-                },
+            const apiUrl = `https://api.apify.com/v2/acts/scrapearchitect~youtube-video-downloader/run-sync-get-dataset-items?token=${settings.apifyToken}`;
+            const apiInput = {
+                video_urls: [{ url: videoUrl }],
+                desired_resolution: '360p', // Lower resolution is fine for audio-only context
             };
 
-            const stream = ytdl(videoUrl, ytdlOptions);
+            const apiResponse = await axios.post(apiUrl, apiInput);
 
-            const chunks = [];
-            stream.on('data', (chunk) => {
-                chunks.push(chunk);
-            });
+            if (apiResponse.data && apiResponse.data.length > 0) {
+                const result = apiResponse.data[0];
+                const audioLink = result.downloadable_audio_link;
 
-            stream.on('end', async () => {
-                const buffer = Buffer.concat(chunks);
-                await sock.sendMessage(msg.key.remoteJid, {
-                    audio: buffer,
-                    mimetype: 'audio/mp4'
-                }, { quoted: msg });
-            });
-
-            stream.on('error', async (err) => {
-                console.error('Error al descargar el audio:', err);
-                await sock.sendMessage(msg.key.remoteJid, { text: 'Ocurrió un error al descargar el audio.' }, { quoted: msg });
-            });
+                if (audioLink) {
+                    const audioBuffer = await axios.get(audioLink, { responseType: 'arraybuffer' });
+                    await sock.sendMessage(msg.key.remoteJid, {
+                        audio: Buffer.from(audioBuffer.data, 'binary'),
+                        mimetype: 'audio/mp4'
+                    }, { quoted: msg });
+                } else {
+                    throw new Error('El API no devolvió un enlace de audio.');
+                }
+            } else {
+                throw new Error('La respuesta del API estaba vacía o en un formato incorrecto.');
+            }
 
         } catch (error) {
             console.error('Error en el comando play:', error);
-            await sock.sendMessage(msg.key.remoteJid, { text: 'Ocurrió un error al buscar la canción.' }, { quoted: msg });
+            const errorMessage = error.response ? JSON.stringify(error.response.data) : error.message;
+            await sock.sendMessage(msg.key.remoteJid, { text: `Ocurrió un error al descargar el audio: ${errorMessage}` }, { quoted: msg });
         }
     }
 };

--- a/plugins/play2.js
+++ b/plugins/play2.js
@@ -1,15 +1,19 @@
 import ytSearch from 'yt-search';
-import ytdl from '@distube/ytdl-core';
+import axios from 'axios';
 
 export default {
     name: 'play2',
     category: 'downloader',
-    description: 'Busca y descarga un video de YouTube.',
+    description: 'Busca y descarga un video de YouTube usando la API de Apify.',
 
     async execute({ sock, msg, args, settings }) {
         const query = args.join(' ');
         if (!query) {
             return await sock.sendMessage(msg.key.remoteJid, { text: 'Por favor, proporciona el nombre de un video.' }, { quoted: msg });
+        }
+
+        if (!settings.apifyToken) {
+            return await sock.sendMessage(msg.key.remoteJid, { text: 'El token de la API de Apify no está configurado. Por favor, añádelo al archivo settings.json.' }, { quoted: msg });
         }
 
         try {
@@ -30,39 +34,36 @@ export default {
                 caption: caption + '\n\nDescargando video, por favor espera...'
             }, { quoted: msg });
 
-            const ytdlOptions = {
-                quality: 'highest',
-                requestOptions: {
-                    headers: {
-                        cookie: settings.youtubeCookies || '',
-                    },
-                },
+            const apiUrl = `https://api.apify.com/v2/acts/scrapearchitect~youtube-video-downloader/run-sync-get-dataset-items?token=${settings.apifyToken}`;
+            const apiInput = {
+                video_urls: [{ url: videoUrl }],
+                desired_resolution: '720p', // A reasonable default quality
             };
 
-            const stream = ytdl(videoUrl, ytdlOptions);
+            const apiResponse = await axios.post(apiUrl, apiInput);
 
-            const chunks = [];
-            stream.on('data', (chunk) => {
-                chunks.push(chunk);
-            });
+            if (apiResponse.data && apiResponse.data.length > 0) {
+                const result = apiResponse.data[0];
+                const videoLink = result.merged_downloadable_link;
 
-            stream.on('end', async () => {
-                const buffer = Buffer.concat(chunks);
-                await sock.sendMessage(msg.key.remoteJid, {
-                    video: buffer,
-                    mimetype: 'video/mp4',
-                    caption: caption
-                }, { quoted: msg });
-            });
-
-            stream.on('error', async (err) => {
-                console.error('Error al descargar el video:', err);
-                await sock.sendMessage(msg.key.remoteJid, { text: 'Ocurrió un error al descargar el video.' }, { quoted: msg });
-            });
+                if (videoLink) {
+                    const videoBuffer = await axios.get(videoLink, { responseType: 'arraybuffer' });
+                    await sock.sendMessage(msg.key.remoteJid, {
+                        video: Buffer.from(videoBuffer.data, 'binary'),
+                        mimetype: 'video/mp4',
+                        caption: caption
+                    }, { quoted: msg });
+                } else {
+                    throw new Error('El API no devolvió un enlace de video.');
+                }
+            } else {
+                throw new Error('La respuesta del API estaba vacía o en un formato incorrecto.');
+            }
 
         } catch (error) {
             console.error('Error en el comando play2:', error);
-            await sock.sendMessage(msg.key.remoteJid, { text: 'Ocurrió un error al buscar el video.' }, { quoted: msg });
+            const errorMessage = error.response ? JSON.stringify(error.response.data) : error.message;
+            await sock.sendMessage(msg.key.remoteJid, { text: `Ocurrió un error al descargar el video: ${errorMessage}` }, { quoted: msg });
         }
     }
 };


### PR DESCRIPTION
- Replaced the entire `ytdl-core`-based download implementation with a more robust solution using the Apify API (`scrapearchitect/youtube-video-downloader` actor).
- This change was made to resolve persistent and recurring download errors (signature errors, 403 Forbidden) that are common with direct `ytdl-core` usage.
- The `play` and `play2` commands have been refactored to call the Apify API.
- The implementation requires the user to provide an `apifyToken` in the `settings.json` file.
- Removed the `@distube/ytdl-core` dependency.