### PR TITLE
feat: Replace download system with ytmp3.mobi API

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { exec as execCallback } from 'child_process';
 import { promisify } from 'util';
+import axios from 'axios';
 
 const exec = promisify(execCallback);
 const settingsPath = path.join(process.cwd(), 'settings.json');
@@ -72,4 +73,50 @@ export async function performUpdate() {
         console.error('Falló el proceso de actualización:', error);
         return `Error durante la actualización: ${error.message}`;
     }
+}
+
+/**
+ * Downloads a YouTube video as audio or video using an external API.
+ * @param {string} url The YouTube video URL.
+ * @param {('mp3'|'mp4')} type The desired format, 'mp3' for audio, 'mp4' for video.
+ * @returns {Promise<{url: string, title: string}>} An object containing the download URL and video title.
+ */
+export async function ytdl(url, type = 'mp4') {
+    const headers = {
+        'accept': '*/*',
+        'accept-language': 'en-US,en;q=0.9',
+        'sec-ch-ua': '"Chromium";v="132", "Not A(Brand";v="8"',
+        'sec-ch-ua-mobile': '?0',
+        'sec-ch-ua-platform': '"Windows"',
+        'sec-fetch-dest': 'empty',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-site': 'cross-site',
+        'referer': 'https://id.ytmp3.mobi/',
+        'referrer-policy': 'strict-origin-when-cross-origin'
+    };
+
+    const videoId = url.match(/(?:youtu\.be\/|youtube\.com\/(?:.*v=|.*\/|.*embed\/))([^&?/]+)/)?.[1];
+    if (!videoId) throw new Error('No se pudo encontrar el ID del video.');
+
+    const initResponse = await axios.get(`https://d.ymcdn.org/api/v1/init?p=y&23=1llum1n471&_=${Date.now()}`, { headers });
+    const init = initResponse.data;
+
+    const convertResponse = await axios.get(`${init.convertURL}&v=${videoId}&f=${type}&_=${Date.now()}`, { headers });
+    const convert = convertResponse.data;
+
+    let info;
+    for (let i = 0; i < 3; i++) {
+        const progressResponse = await axios.get(convert.progressURL, { headers });
+        info = progressResponse.data;
+        if (info.progress === 3) break;
+        await new Promise(r => setTimeout(r, 1000));
+    }
+
+    if (!info || !convert.downloadURL) throw new Error('No se pudo obtener el enlace de descarga desde la API.');
+
+    if (type === 'mp3' && info.duration > 360) { // 6 minutes
+        throw new Error('El audio es demasiado largo (>6 minutos).');
+    }
+
+    return { url: convert.downloadURL, title: info.title || 'Archivo de YouTube' };
 }

--- a/plugins/play.js
+++ b/plugins/play.js
@@ -1,19 +1,16 @@
 import ytSearch from 'yt-search';
 import axios from 'axios';
+import { ytdl } from '../lib/functions.js';
 
 export default {
     name: 'play',
     category: 'downloader',
-    description: 'Busca y descarga una canción de YouTube usando la API de Apify.',
+    description: 'Busca y descarga una canción de YouTube.',
 
-    async execute({ sock, msg, args, settings }) {
+    async execute({ sock, msg, args }) {
         const query = args.join(' ');
         if (!query) {
             return await sock.sendMessage(msg.key.remoteJid, { text: 'Por favor, proporciona el nombre de una canción.' }, { quoted: msg });
-        }
-
-        if (!settings.apifyToken) {
-            return await sock.sendMessage(msg.key.remoteJid, { text: 'El token de la API de Apify no está configurado. Por favor, añádelo al archivo settings.json.' }, { quoted: msg });
         }
 
         try {
@@ -26,7 +23,6 @@ export default {
                 return await sock.sendMessage(msg.key.remoteJid, { text: 'No se encontraron resultados.' }, { quoted: msg });
             }
 
-            const videoUrl = video.url;
             const caption = `*Título:* ${video.title}\n*Duración:* ${video.timestamp}\n*Autor:* ${video.author.name}`;
 
             await sock.sendMessage(msg.key.remoteJid, {
@@ -34,35 +30,17 @@ export default {
                 caption: caption + '\n\nDescargando audio, por favor espera...'
             }, { quoted: msg });
 
-            const apiUrl = `https://api.apify.com/v2/acts/scrapearchitect~youtube-video-downloader/run-sync-get-dataset-items?token=${settings.apifyToken}`;
-            const apiInput = {
-                video_urls: [{ url: videoUrl }],
-                desired_resolution: '360p', // Lower resolution is fine for audio-only context
-            };
+            const result = await ytdl(video.url, 'mp3');
+            const audioBuffer = await axios.get(result.url, { responseType: 'arraybuffer' });
 
-            const apiResponse = await axios.post(apiUrl, apiInput);
-
-            if (apiResponse.data && apiResponse.data.length > 0) {
-                const result = apiResponse.data[0];
-                const audioLink = result.downloadable_audio_link;
-
-                if (audioLink) {
-                    const audioBuffer = await axios.get(audioLink, { responseType: 'arraybuffer' });
-                    await sock.sendMessage(msg.key.remoteJid, {
-                        audio: Buffer.from(audioBuffer.data, 'binary'),
-                        mimetype: 'audio/mp4'
-                    }, { quoted: msg });
-                } else {
-                    throw new Error('El API no devolvió un enlace de audio.');
-                }
-            } else {
-                throw new Error('La respuesta del API estaba vacía o en un formato incorrecto.');
-            }
+            await sock.sendMessage(msg.key.remoteJid, {
+                audio: Buffer.from(audioBuffer.data, 'binary'),
+                mimetype: 'audio/mp4'
+            }, { quoted: msg });
 
         } catch (error) {
             console.error('Error en el comando play:', error);
-            const errorMessage = error.response ? JSON.stringify(error.response.data) : error.message;
-            await sock.sendMessage(msg.key.remoteJid, { text: `Ocurrió un error al descargar el audio: ${errorMessage}` }, { quoted: msg });
+            await sock.sendMessage(msg.key.remoteJid, { text: `Ocurrió un error al descargar el audio: ${error.message}` }, { quoted: msg });
         }
     }
 };

--- a/plugins/play2.js
+++ b/plugins/play2.js
@@ -1,19 +1,16 @@
 import ytSearch from 'yt-search';
 import axios from 'axios';
+import { ytdl } from '../lib/functions.js';
 
 export default {
     name: 'play2',
     category: 'downloader',
-    description: 'Busca y descarga un video de YouTube usando la API de Apify.',
+    description: 'Busca y descarga un video de YouTube.',
 
-    async execute({ sock, msg, args, settings }) {
+    async execute({ sock, msg, args }) {
         const query = args.join(' ');
         if (!query) {
             return await sock.sendMessage(msg.key.remoteJid, { text: 'Por favor, proporciona el nombre de un video.' }, { quoted: msg });
-        }
-
-        if (!settings.apifyToken) {
-            return await sock.sendMessage(msg.key.remoteJid, { text: 'El token de la API de Apify no está configurado. Por favor, añádelo al archivo settings.json.' }, { quoted: msg });
         }
 
         try {
@@ -26,7 +23,6 @@ export default {
                 return await sock.sendMessage(msg.key.remoteJid, { text: 'No se encontraron resultados.' }, { quoted: msg });
             }
 
-            const videoUrl = video.url;
             const caption = `*Título:* ${video.title}\n*Duración:* ${video.timestamp}\n*Autor:* ${video.author.name}`;
 
             await sock.sendMessage(msg.key.remoteJid, {
@@ -34,36 +30,18 @@ export default {
                 caption: caption + '\n\nDescargando video, por favor espera...'
             }, { quoted: msg });
 
-            const apiUrl = `https://api.apify.com/v2/acts/scrapearchitect~youtube-video-downloader/run-sync-get-dataset-items?token=${settings.apifyToken}`;
-            const apiInput = {
-                video_urls: [{ url: videoUrl }],
-                desired_resolution: '720p', // A reasonable default quality
-            };
+            const result = await ytdl(video.url, 'mp4');
+            const videoBuffer = await axios.get(result.url, { responseType: 'arraybuffer' });
 
-            const apiResponse = await axios.post(apiUrl, apiInput);
-
-            if (apiResponse.data && apiResponse.data.length > 0) {
-                const result = apiResponse.data[0];
-                const videoLink = result.merged_downloadable_link;
-
-                if (videoLink) {
-                    const videoBuffer = await axios.get(videoLink, { responseType: 'arraybuffer' });
-                    await sock.sendMessage(msg.key.remoteJid, {
-                        video: Buffer.from(videoBuffer.data, 'binary'),
-                        mimetype: 'video/mp4',
-                        caption: caption
-                    }, { quoted: msg });
-                } else {
-                    throw new Error('El API no devolvió un enlace de video.');
-                }
-            } else {
-                throw new Error('La respuesta del API estaba vacía o en un formato incorrecto.');
-            }
+            await sock.sendMessage(msg.key.remoteJid, {
+                video: Buffer.from(videoBuffer.data, 'binary'),
+                mimetype: 'video/mp4',
+                caption: caption
+            }, { quoted: msg });
 
         } catch (error) {
             console.error('Error en el comando play2:', error);
-            const errorMessage = error.response ? JSON.stringify(error.response.data) : error.message;
-            await sock.sendMessage(msg.key.remoteJid, { text: `Ocurrió un error al descargar el video: ${errorMessage}` }, { quoted: msg });
+            await sock.sendMessage(msg.key.remoteJid, { text: `Ocurrió un error al descargar el video: ${error.message}` }, { quoted: msg });
         }
     }
 };


### PR DESCRIPTION
- Replaced all previous download logic (`ytdl-core`, Apify API) with a new implementation based on the ytmp3.mobi API, as requested by the user.
- Created a new reusable `ytdl` function in `lib/functions.js` to handle the API interaction.
- Refactored the `play` command to use this new function for audio downloads.
- Refactored the `play2` command to use this new function for video downloads.
- This approach is more stable and does not require any external API keys or cookies from the user.
- Removed the `@distube/ytdl-core` dependency.