### PR TITLE
feat: Add owner-only chat command for updates

### DIFF
--- a/plugins/update.js
+++ b/plugins/update.js
@@ -5,7 +5,17 @@ export default {
     category: 'owner', // Even if public, it's an owner-level action
     description: 'Actualiza el bot a la última versión desde GitHub.',
 
-    async execute({ sock, msg }) {
+    async execute({ sock, msg, settings }) {
+        // Owner check
+        const senderJid = msg.sender;
+        const ownerJids = [settings.ownerLidJid, settings.ownerPhoneJid].filter(Boolean);
+
+        if (!ownerJids.includes(senderJid)) {
+            return await sock.sendMessage(msg.key.remoteJid, {
+                text: 'Este comando solo puede ser utilizado por el propietario del bot.'
+            }, { quoted: msg });
+        }
+
         await sock.sendMessage(msg.key.remoteJid, {
             text: 'Buscando actualizaciones...'
         }, { quoted: msg });


### PR DESCRIPTION
- Implements the `update` command to be functional from the chat.
- Adds a critical security check to `plugins/update.js` to ensure only the bot owner can execute the command.
- The command correctly calls the `performUpdate` helper function to pull the latest changes from Git and restart the bot.
- Provides feedback messages to the user in the chat during the update process.