### PR TITLE
fix: Untrack settings.json to prevent update conflicts

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,0 @@
-{
-  "botName": "JulesBot",
-  "ownerName": "Jules",
-  "ownerLidJid": "",
-    "ownerPhoneJid": ""
-}


### PR DESCRIPTION
- Removes `settings.json` from the Git index using `git rm --cached`.
- The file is already in `.gitignore`, but since it was tracked previously, this step is necessary.
- This change will prevent `git pull` from failing during updates due to local modifications in the user's `settings.json` file.