### PR TITLE
fix: Prevent crash on missing settings.json

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -16,13 +16,30 @@ export async function readSettings() {
         const data = await fs.readFile(settingsPath, 'utf-8');
         return JSON.parse(data);
     } catch (error) {
-        console.error("Error al leer settings.json:", error);
-        // Devuelve valores por defecto si el archivo no existe o hay un error
-        return {
-            botName: "JulesBot",
-            ownerName: "Jules",
-            ownerNumber: "1234567890"
-        };
+        if (error.code === 'ENOENT') {
+            console.log('settings.json no encontrado. Creando uno por defecto.');
+            const defaultSettings = {
+                botName: "JulesBot",
+                ownerName: "Jules",
+                ownerLidJid: "",
+                ownerPhoneJid: "",
+                apifyToken: ""
+            };
+            // Write the default settings to the file
+            await writeSettings(defaultSettings);
+            // Return the default settings
+            return defaultSettings;
+        } else {
+            console.error("Error al leer settings.json:", error);
+            // For other errors, just return a default object in memory
+            return {
+                botName: "JulesBot",
+                ownerName: "Jules",
+                ownerLidJid: "",
+                ownerPhoneJid: "",
+                apifyToken: ""
+            };
+        }
     }
 }
 


### PR DESCRIPTION
- Modified the `readSettings` function in `lib/functions.js` to be more robust.
- If `settings.json` is not found on startup, the function now creates a default `settings.json` file.
- This prevents the bot from crashing due to a missing settings file, which could occur after a `git pull` if the file was untracked.