### PR TITLE
fix: Suppress console logs from Baileys

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,20 @@
 import { Boom } from '@hapi/boom';
 import { makeWASocket, DisconnectReason, useMultiFileAuthState, fetchLatestBaileysVersion } from '@whiskeysockets/baileys';
-import pino from 'pino';
 import fs from 'fs';
 import path from 'path';
 import axios from 'axios';
 import { server, io, appEvents } from './server.js';
 import { readSettings } from './lib/functions.js';
 
-const logger = pino({ level: 'silent' }).child({ level: 'silent' });
+const logger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    fatal: () => {},
+    trace: () => {},
+    child: () => this,
+};
 const commands = new Map();
 let botSettings = {};
 


### PR DESCRIPTION
- Replaces the pino logger with a no-op (dummy) logger.
- This effectively silences all console output from the Baileys library, including the harmless but verbose "Bad MAC" and session errors, resulting in a cleaner console.

fix: Consolidate and fix play command

- Implements the user's request to have a single, stable `play` command.
- The command now downloads video by default, using the `ytmp3.mobi` API via a helper function in `lib/functions.js`.
- The old, conflicting reaction-based download system has been removed from `index.js`.
- This resolves the startup crash caused by previous faulty implementations.